### PR TITLE
 Fix for path option on ace dependency call

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -17,11 +17,11 @@ defmodule Watercooler.Mixfile do
 
   defp deps do
     [
-      {:ace, path: "~> 0.18.0"},
+      {:ace, "~> 0.18.0"},
       {:phoenix_html, "~> 2.11"},
       {:raxx_static, "~> 0.7.0"},
       {:server_sent_event, "~> 0.3.1"},
-      {:exsync, "~> 0.2.3", only: :dev},
+      {:exsync, "~> 0.2.3"},
     ]
   end
 end

--- a/mix.exs
+++ b/mix.exs
@@ -21,7 +21,7 @@ defmodule Watercooler.Mixfile do
       {:phoenix_html, "~> 2.11"},
       {:raxx_static, "~> 0.7.0"},
       {:server_sent_event, "~> 0.3.1"},
-      {:exsync, "~> 0.2.3"},
+      {:exsync, "~> 0.2.3", only: :dev},
     ]
   end
 end


### PR DESCRIPTION
Fix for ace dependency removes `path:` option, which will throw an error when you invoke `mix deps.get`